### PR TITLE
Add a Jekyll-Scholar filter that converts UTF-8 rendered BibTeX to ISO-8859-1 encoded HTML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ scholar:
   source: ./_data
   bibliography: publications.bib
   style: _csl/ieee.csl
-  bibtex_filters: [smallcaps,superscript]
+  bibtex_filters: [latex,smallcaps,superscript,Unicode_to_HTML]
   bibliography_template: bib
   bibliography_list_tag: 'ul
                           style="list-style-type: none;

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -16,9 +16,7 @@
     {% endif %}
     <div class="media-body">
       <h6 id="citation" class="media-heading">
-        {%- assign close-curly = '}' -%}
-        {%- assign eacute = "{\'e}" -%}
-        {{ reference | replace: "--", "&ndash;" | replace: eacute, "&eacute;" | replace: "\&", "&" | replace: '{', '' | replace: close-curly, '' }}
+        {{ reference }}
       </h6>
       <strong>Status:</strong>
       {% if entry.status %}

--- a/_plugins/unicode-to-html.rb
+++ b/_plugins/unicode-to-html.rb
@@ -1,0 +1,32 @@
+# Jekyll-Scholar BibTeX filter to convert rendered BibTeX from UTF-8 to ISO-8859-1.
+# Citeproc and Citeproc-ruby (used by Jekyll-Scholar) both produce only utf-8 output.
+# While we could patch them to be encoding-aware, our desired target encoding is missing
+# characters such as curly double quotes, endashes, and the like.
+# Since we are rendering ISO-8859-1 HTML (as opposed to just ISO-8859-1 text), we can use
+# HTML entities to display these missing characters instead.
+# This is well out of the scope of what Citeproc wants to do, so we take a hackier approach.
+# Unfortunately, Jekyll's config is not in scope, so we have to hard-code the encoding
+# rather than reading it out of _config.yml.
+
+# Convert utf-8 to ISO-8859-1, replacing unicode characters not in ISO-8859-1 with xml-encoded entities.
+HTML_CONV = Encoding::Converter.new('utf-8', 'ISO-8859-1', :xml => :text)
+
+# This filter needs to run after all filters that might produce unicode text have run.
+module Jekyll
+  class Scholar
+    class Unicode_to_HTML < BibTeX::Filter
+      def apply(value)
+        HTML_CONV.convert(value)
+      end
+    end
+  end
+end
+
+# CiteProc has one utf-8 encoded regex that is matched against text after it has been run through
+# all the filters. This monkey-patches the regex to have the right encoding.
+module CiteProc
+  class Name
+    @romanesque =
+      Regexp.new("^[\p{Latin}\p{Greek}\p{Cyrillic}\p{Hebrew}\p{Armenian}\p{Georgian}\p{Common}]*$".force_encoding("ISO-8859-1"))
+  end
+end


### PR DESCRIPTION
And remove the rendering-latex-via-string-substitution hacks!